### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://xpsgreen.visualstudio.com/236e50c1-9396-40a6-87de-62c2c5bd0708/da357934-0743-4bf3-b73a-52c7f7b0f75f/_apis/work/boardbadge/bff1dc1d-f9a2-4879-9a95-44691f3c95df)](https://xpsgreen.visualstudio.com/236e50c1-9396-40a6-87de-62c2c5bd0708/_boards/board/t/da357934-0743-4bf3-b73a-52c7f7b0f75f/Microsoft.RequirementCategory)
 # chris-e-green.github.io


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://xpsgreen.visualstudio.com/236e50c1-9396-40a6-87de-62c2c5bd0708/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.